### PR TITLE
fix: export Parser (EXP-826)

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,4 @@
-(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Parser = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 (function (process,Buffer){
 'use strict'
 
@@ -15326,4 +15326,5 @@ exports.YAMLSemanticError = err.YAMLSemanticError
 exports.YAMLSyntaxError = err.YAMLSyntaxError
 exports.YAMLWarning = err.YAMLWarning
 
-},{"./dist/cst/Node":68,"./dist/errors":77,"./dist/schema/Map":83,"./dist/schema/parseMap":90,"./dist/schema/parseSeq":91,"./dist/stringify":93,"./dist/toJSON":108}]},{},[1]);
+},{"./dist/cst/Node":68,"./dist/errors":77,"./dist/schema/Map":83,"./dist/schema/parseMap":90,"./dist/schema/parseSeq":91,"./dist/stringify":93,"./dist/toJSON":108}]},{},[1])(1)
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tap": "^14.4.1"
   },
   "scripts": {
-    "build": "browserify index.js > browser.js",
+    "build": "browserify index.js --standalone Parser --outfile browser.js",
     "snap": "tap",
     "test": "tap",
     "preversion": "npm test && npm run build",


### PR DESCRIPTION
### Commits

- fix: export Parser  
  Apparently, Browserify does not preserve exports by default, so the
  browser bundle was not exporting the `Parser` class. This sort of
  makes sense given that Browserify was built for usage with
  applications, not libraries.
  
  Adding the `--standalone` flag adds the appropriate export in the
  bundle.